### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/Bazenga/06f1e14a-1271-4ee1-a97e-2cafe3ffaaf0/b7d3e20a-67e7-415a-85c0-c68be2f26dd1/_apis/work/boardbadge/d1c18a68-dad2-46d8-bb42-60a73209b5ed)](https://dev.azure.com/Bazenga/06f1e14a-1271-4ee1-a97e-2cafe3ffaaf0/_boards/board/t/b7d3e20a-67e7-415a-85c0-c68be2f26dd1/Microsoft.RequirementCategory)
 # Astro
 
 ## School Management Dashboard


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/Bazenga/06f1e14a-1271-4ee1-a97e-2cafe3ffaaf0/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.